### PR TITLE
Update: format to notification comment | Added: processes for comment when responsible has changed

### DIFF
--- a/Config/config.php
+++ b/Config/config.php
@@ -292,6 +292,11 @@ return [
         'type' => 'statusChanged',
         'icon'  => 'fa fa-info-circle',
         'color' => '#fae100' //yellow
+      ],
+      'responsibleChanged' => [
+        'type' => 'responsibleChanged',
+        'icon'  => 'fa fa-info-circle',
+        'color' => 'green-9' //green
       ]
 
     ]

--- a/Events/Handlers/CheckResponsibleRequestable.php
+++ b/Events/Handlers/CheckResponsibleRequestable.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Modules\Requestable\Events\Handlers;
+
+class CheckResponsibleRequestable
+{
+    private $log = "Requestable: Handler|CheckResponsibleRequestable|";
+    private $commentService;
+
+    public function __construct()
+    {
+        $this->commentService = app("Modules\Icomments\Services\CommentService");
+    }
+
+    /**
+     * Init handle
+    */
+    public function handle($event){
+
+        try {
+
+            //Model
+            $requestable = $event->requestable;
+            //\Log::info($this->log."ID: ".$requestable->id);
+        
+            if(get_class($event)=="Modules\Requestable\Events\RequestableWasUpdated"){
+                
+                if($requestable->wasChanged("responsible_id")){
+                    //\Log::info($this->log."createComment");
+                    $this->createComment($requestable); 
+                }
+                
+            }
+
+        } catch (\Exception $e) {
+            \Log::error($this->log.'Message: ' . $e->getMessage() . ' | FILE: ' . $e->getFile() . ' | LINE: ' . $e->getLine());
+        }
+
+        
+    }// If handle
+
+
+    private function createComment($model)
+    {
+        
+        $comment = trans('requestable::requestables.responsible.updated',['responsible' => $model->responsible->present()->fullname]);
+
+        $this->commentService->create($model,[
+                "comment" => $comment,
+                "internal" => true,
+                "type" => "responsibleChanged"
+            ]
+        );
+
+    }
+   
+}

--- a/Jobs/ProcessNotification.php
+++ b/Jobs/ProcessNotification.php
@@ -263,20 +263,20 @@ class ProcessNotification implements ShouldQueue
     public function saveComment($type,$model,$message,$from=null,$to=null)
     {
 
-        $comment = "<strong>".trans('requestable::common.notifications.title sent')."</strong>";
-        $comment = $comment."<p><strong>".trans('requestable::common.notifications.type').":</strong>".$type."</p>";
+        $comment = trans('requestable::common.notifications.title sent');
+        $comment = $comment." <b>".$type."</b>";
        
-        if(!is_null($from))
-            $comment = $comment."<p><strong>".trans('requestable::common.notifications.from').":</strong>".$from."</p>";
+        if(!is_null($from) && !empty($from))
+            $comment = $comment." ".trans('requestable::common.notifications.from')." <b>".$from."</b>";
 
         if(!is_null($to)){
             if(is_array($to))
                 $to = implode(" ",$to);
             
-            $comment = $comment."<p><strong>".trans('requestable::common.notifications.to').":</strong>".$to."</p>";
+            $comment = $comment." ".trans('requestable::common.notifications.to')." <b>".$to."</b>";
         }
 
-        $comment = $comment."<p><strong>".trans('requestable::common.notifications.message').":</strong>".$message."</p>";
+        $comment = $comment."<p>".$message."</p>";
 
         $this->commentService->create($model,[
                 "user_id" => $model->updated_by, // Needed because is a job

--- a/Providers/EventServiceProvider.php
+++ b/Providers/EventServiceProvider.php
@@ -14,6 +14,7 @@ use Modules\Requestable\Events\CategoryWasCreated;
 use Modules\Requestable\Events\Handlers\CheckStatusRequestable;
 use Modules\Iforms\Events\LeadWasCreated;
 use Modules\Requestable\Events\Handlers\CreateRequestableByLeadData;
+use Modules\Requestable\Events\Handlers\CheckResponsibleRequestable;
 
 use Modules\Requestable\Events\Handlers\CreateFormAndStatusesToCategory;
 
@@ -25,7 +26,8 @@ class EventServiceProvider extends ServiceProvider
             CheckStatusRequestable::class
         ],
         RequestableWasUpdated::class => [
-            CheckStatusRequestable::class
+            CheckStatusRequestable::class,
+            CheckResponsibleRequestable::class
         ],
         LeadWasCreated::class => [
             CreateRequestableByLeadData::class

--- a/Resources/lang/en/common.php
+++ b/Resources/lang/en/common.php
@@ -27,10 +27,10 @@ return [
   ],
   'notifications' => [
     "comment" => ' Notification Type: :type -- Message: :message',
-    "title sent" => 'Sent Notification',
+    "title sent" => 'Sent',
     "type" => 'Type',
-    "from" => 'From',
-    "to" => 'To',
+    "from" => 'from',
+    "to" => 'to',
     "message" => 'Message'
   ],
   'notFound' => 'Item not found',

--- a/Resources/lang/en/requestables.php
+++ b/Resources/lang/en/requestables.php
@@ -29,4 +29,7 @@ return [
     ],
     'validation' => [
     ],
+    'responsible' => [
+        'updated' => "Responsible has been updated to: :responsible"
+    ]
 ];

--- a/Resources/lang/es/common.php
+++ b/Resources/lang/es/common.php
@@ -24,10 +24,10 @@ return [
   ],
   'notifications' => [
     "comment" => 'Notificacion de: :type -- Mensaje: :message',
-    "title sent" => 'Notificacion enviada',
+    "title sent" => 'Enviado',
     "type" => 'Tipo',
-    "from" => 'De',
-    "to" => 'Para',
+    "from" => 'de',
+    "to" => 'para',
     "message" => 'Mensaje',
     "titleReportNewDocument" => 'Nuevo Documento Asignado En Tu Solicitud',
     "MessageReportNewDocument" => 'Documento Asignado: ',

--- a/Resources/lang/es/requestables.php
+++ b/Resources/lang/es/requestables.php
@@ -34,4 +34,7 @@ return [
     ],
     'validation' => [
     ],
+    'responsible' => [
+        'updated' => "Se ha actualizado el responsable a: :responsible"
+    ]
 ];


### PR DESCRIPTION
Asi quedó según la estructura que conversamos:

![newFormat](https://github.com/imagina/imaginacms-requestable/assets/8865099/5f972837-5458-4c4d-b6e3-267453b6e3dc)
